### PR TITLE
add callbacks so images load

### DIFF
--- a/html/js/sample.js
+++ b/html/js/sample.js
@@ -3,8 +3,11 @@ draw(circle(30, "red"));
 print("Hello world!");
 print("Calculating (1 + 2 - 3): " + (1 + 2 - 3));
 
-print("SMASH THE STATE");
 draw(rectangle(125, 75, "black"));
+
+loadImage("smile",smile);
+
+draw(image("smile"));
 
 var eye = overlay(circle(10, "black"), circle(30, "purple"));
 
@@ -21,23 +24,6 @@ draw(overlay(eyes, overlay(mouth, circle(100, "green"))));
 var collage = placeImage(circle(10,"black"),circle(20,"white"), 0, 0);
 draw(placeImage(collage, circle(30, "red"), 0, 0));
 
-var faceEar = placeImage(circle(30, "white"), circle(100,"white"), 0 , 0);
+loadImage("skull", "http://cursors4.totallyfreecursors.com/thumbnails/skull-crossbones1.gif");
 
-var face = placeImage(circle(30, "white"), faceEar, 140, 0);
-
-var leftEye = placeImage(circle(35,"black"), face, 25, 25);
-
-var head = placeImage(circle(35,"black"), leftEye, 100, 25);
-
-var scene = emptyScene(300, 400);
-
-draw(placeImage(head, scene, 0, 0));
-
-var body = overlay(circle(70, "white"),circle(125, "black"));
-
-var withLeft = placeImage(circle(25, "white"), body, 50, 200);
-var bodyWithFeet = placeImage(circle(25, "white"), withLeft, 130, 200);
-
-var bodyScene = placeImage(bodyWithFeet, scene, 0, 150);
-
-draw(placeImage(head, bodyScene, 40, 0));
+draw(overlay(image("skull"), rectangle(125, 75, "black")));

--- a/html/js/tlc.js
+++ b/html/js/tlc.js
@@ -8,13 +8,17 @@ output.id = "output";
 var source = document.createElement("div");
 source.id = "source";
 
+var images = document.createElement("div");
+images.id = "images";
+
 var body = document.getElementsByTagName("body")[0];
 body.appendChild(source);
+body.appendChild(images);
 body.appendChild(output);
 
 var style = document.createElement("style");
 
-style.textContent = "#output { width: 45%; float: left; } #source { width: 45%; float: left; } .output { border-bottom: 1px solid #ccc; padding: 10px 0; }";
+style.textContent = "#output { width: 45%; float: left; } #source { width: 45%; float: left; } .output { border-bottom: 1px solid #ccc; padding: 10px 0; } #images { width: 45%; float: right; } ";
 
 body.appendChild(style);
 
@@ -83,30 +87,32 @@ function rectangle(width, height, color) {
            height: height };
 }
 
-/* image :: url -> shape */
-function image(location) {
-  var img = new Image()
-  //img.src = location;
-  //img.style.visibility = "hidden"
+function loadImage (name, location) {
+  var img = document.createElement("img");
+  img.id = name;
 
-  // append the node, get the dimensions, and remove it again
-  //document.body.appendChild(img);
-  //var imgClone = img.cloneNode();
-  //document.body.removeChild(img);
+  img.src = location;
+  
+  images.appendChild(img);
+}
+
+/* image :: url -> shape */
+function image(name) {
+  
+  var img = document.getElementById(name);
 
   var imgShape = { tlc_dt: "image",
                    img: img,
-                   locaton: location
+                   locaton: location,
+                   width: img.width,
+                   height: img.height,
+                   x: 0,
+                   y: 0,
                  };
 
-  img.onload = function() {
-    imgShape.width = img.width;
-    imgShape.height = img.height;
-  };
-
-  img.src = location;
-
-  return [imgShape];
+  return { elements: [imgShape],
+           width: img.width,
+           height: img.height };
 }
 
 /* draw :: scene -> nothing */
@@ -138,10 +144,17 @@ function draw(scene) {
       ctx.fill();
       break;
     case "image":
-      shape.img.onload = function() {
+      // if image has loaded, draw it, else add callback
+      if (shape.img.complete || shape.img.naturalWidth) {
         ctx.drawImage(shape.img,
                       shape.x,
                       shape.y);
+      } else {
+        shape.img.onload = function() {
+          ctx.drawImage(shape.img,
+                        shape.x,
+                        shape.y);
+        };
       }
       break;
     default:
@@ -188,4 +201,4 @@ function placeImage(foreground, background, x, y) {
   return scene;
 }
 
-var smile = "smile.gif";
+var smile = "js/smile.gif";


### PR DESCRIPTION
Now you can add images. I can't figure out how to make it work without callbacks, and it doesn't work perfectly with callbacks either.

My first attempt was `draw(image("http://location-url-blah/"))`, but the problem is that `draw()` adds the new "div" with the scene immediately, but the images take time to load. So when the canvas is drawn and added to the document, the image isn't there, so the canvas is blank. Also, `draw()` tries to make a canvas the size of the scene -- but when the image isn't loaded yet, the width and height are zero. 

So I tried a couple things:

1) Make adding images a two-step process -- you load images into an image bank with `loadImage("name", "http://location-url")`, then get a scene with that image with `image("name")`. This works great, as long as you're adding images in the browser console. In a script, the image is loaded and the scene created at the same time, so it doesn't work.

2) To fix that, I added this mess in the `draw()` function:
```(js)
    case "image":
      // if image has loaded, draw it, else add callback
      if (shape.img.complete || shape.img.naturalWidth) {
        ctx.drawImage(shape.img,
                      shape.x,
                      shape.y);
      } else {
        shape.img.onload = function() {
          ctx.drawImage(shape.img,
                        shape.x,
                        shape.y);
        };
      }
      break;
```
So it checks if the image has loaded. If it's loaded, it draws the image immediately. If not, then it adds an "onload" callback that will draw the image later once it's done loading.

Now scripts work, but there's still the problem of `draw()` not knowing the size of a not-yet-loaded image.

Now I wonder, if I'm stuck using callbacks, should I just forget about breaking it into two steps? I think I'll try that next.